### PR TITLE
Added missing -m32 compile flag for ia32 builds

### DIFF
--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -73,11 +73,13 @@ feature(ia32) {
   specific (prop:windows) {
     libpaths += $(PIN_ROOT)/ia32/lib \
                 $(PIN_ROOT)/ia32/lib-ext
-  }
 
-  specific (prop:windows) {
     // DO NOT CHANGE ORDER
     lit_libs += libcpmt libcmt pinvm pin libxed ntdll-32
+  }
+  
+  specific (make, gnuace) {
+    compile_flags += -m32
   }
 }
 


### PR DESCRIPTION
The 32-built builds on non-Windows systems was missing the -m32 compile flags. I also removed duplicate ```specific(prop:windows)``` sections from the configuration file.