### PR TITLE
Remove Debug configuration on Windows

### DIFF
--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -24,6 +24,7 @@ project {
 
   specific (prop:windows) {
     macros += TARGET_WINDOWS _SECURE_SCL=0
+    configurations -= Debug
 
     DisableSpecificWarning += 4530
     IgnoreAllDefaultLibraries = true


### PR DESCRIPTION
Pin does not support compiling the Debug version on Windows. This will lead to linker errors since the Pin provides with on system libraries that do not have any debug symbols.