### PR TITLE
modify bug for template script to generate VC 2013

### DIFF
--- a/templates/vc10.mpd
+++ b/templates/vc10.mpd
@@ -25,9 +25,11 @@
 <%foreach(platforms)%>
 <%foreach(configurations)%>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='<%configuration%>|<%platform%>'" Label="Configuration">
-    <ConfigurationType><%if(type_is_dynamic)%>DynamicLibrary<%else%><%if(type_is_static && staticname)%>StaticLibrary<%else%><%if(custom_only)%>Utility<%else%><%if(makeoutput)%>Makefile<%else%>Application<%endif%><%endif%><%endif%><%endif%></ConfigurationType>
+    <ConfigurationType><%if(type_is_static && staticname)%>StaticLibrary<%else%><%if(type_is_dynamic)%>DynamicLibrary<%else%><%if(custom_only)%>Utility<%else%><%if(makeoutput)%>Makefile<%else%>Application<%endif%><%endif%><%endif%><%endif%></ConfigurationType>
 <%if(UseOfMFC)%>
-    <UseOfMfc><%UseOfMFC%></UseOfMfc>
+    <UseOfMfc><%if(compares(UseOfMFC,1))%>Static<%else%><%if(compares(UseOfMFC,2))%>Dynamic<%endif%><%endif%></UseOfMfc>
+<%else%>
+	<UseOfMfc>false</UseOfMfc>
 <%endif%>
 <%if(UseOfATL)%>
     <UseOfAtl><%UseOfATL%></UseOfAtl>
@@ -88,7 +90,7 @@
     <NMakeCleanCommandLine><%makeclean%> CONF=<%configuration%></NMakeOutput>
     <NMakeOutput><%makeoutput%></NMakeOutput>
 <%else%>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='<%configuration%>|<%platform%>'"><%if(type_is_dynamic)%><%if(dllout)%><%dllout%>\<%else%><%libout%>\<%endif%><%else%><%if(type_is_static)%><%libout%>\<%else%><%if(exeout)%><%exeout%>\<%if(windows_style)%><%output_dir("Debug")%>\<%endif%><%else%><%if(windows_style)%><%output_dir("Debug")%>\<%else%><%output_dir(".")%>\<%endif%><%endif%><%endif%><%endif%></OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='<%configuration%>|<%platform%>'"><%if(type_is_dynamic)%><%if(dllout)%><%dllout%><%else%><%libout%><%endif%><%else%><%if(type_is_static&&staticname)%><%libout%><%else%><%if(exeout)%><%exeout%><%if(windows_style)%>\<%output_dir("Debug")%><%endif%><%else%><%if(windows_style)%><%output_dir("Debug")%><%else%><%output_dir(".")%><%endif%><%endif%><%endif%><%endif%></OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='<%configuration%>|<%platform%>'"><%if(intdir)%><%intdir%>\<%else%><%intermediate_dir%>\<%noextension(project_file)%>\<%if(output_subdir)%><%output_subdir%>\<%endif%><%endif%></IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='<%configuration%>|<%platform%>'"><%if(debug_prj)%>true<%else%>false<%endif%></LinkIncremental>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='<%configuration%>|<%platform%>'"><%if(type_is_dynamic)%><%libname_prefix%><%sharedname%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%else%><%if(type_is_static)%><%libname_prefix%><%staticname%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%else%><%exename%><%if(use_exe_modifier)%><%lib_modifier%><%endif%><%endif%><%endif%></TargetName>
@@ -193,7 +195,13 @@
 <%if(SmallerTypeCheck)%>
       <SmallerTypeCheck>true</SmallerTypeCheck>
 <%endif%>
-      <RuntimeLibrary><%if(runtime_library)%><%runtime_library%><%else%><%if(type_is_static || need_staticflags)%><%if(debug_prj)%>MultiThreadedDebug<%else%>MultiThreaded<%endif%><%else%><%if(debug_prj)%>MultiThreadedDebugDLL<%else%>MultiThreadedDLL<%endif%><%endif%><%endif%></RuntimeLibrary>
+
+<%if(runtime_library)%>
+	<RuntimeLibrary><%if(compares(runtime_library,0))%>MultiThreaded<%else%><%if(compares(runtime_library,1))%>MultiThreadedDebug<%else%><%if(compares(runtime_library,2))%>MultiThreadedDLL<%else%><%if(compares(runtime_library,3))%>MultiThreadedDebugDLL<%endif%><%endif%><%endif%><%endif%></RuntimeLibrary>
+<%else%>
+      <RuntimeLibrary><%if(type_is_static || need_staticflags)%><%if(debug_prj)%>MultiThreadedDebug<%else%>MultiThreaded<%endif%><%else%><%if(debug_prj)%>MultiThreadedDebugDLL<%else%>MultiThreadedDLL<%endif%><%endif%></RuntimeLibrary>
+<%endif%>
+	  
 <%if(StructMemberAlignment)%>
       <StructMemberAlignment><%StructMemberAlignment%></StructMemberAlignment>
 <%endif%>
@@ -272,9 +280,11 @@
       <BrowseInformationFile><%BrowseInformationFile%></BrowseInformationFile>
 <%endif%>
       <WarningLevel><%if(compares(warning_level, all))%>EnableAllWarnings<%else%><%if(compares(warning_level, none) || compares(warning_level, 0))%>TurnOffAllWarnings<%else%>Level<%warning_level("3")%><%endif%><%endif%></WarningLevel>
+
 <%if(!managed && debug_format)%>
-      <DebugInformationFormat><%debug_format%></DebugInformationFormat>
+      <DebugInformationFormat><%if(compares(debug_format, 0))%>None<%else%><%if(compares(debug_format, 1))%>OldStyle<%else%><%if(compares(debug_format, 2))%>ProgramDatabase<%else%><%if(compares(debug_format, 3))%>EditAndContinue<%endif%><%endif%><%endif%><%endif%></DebugInformationFormat>
 <%endif%>
+
 <%if(CallingConvention)%>
       <CallingConvention><%CallingConvention%></CallingConvention>
 <%endif%>
@@ -337,12 +347,12 @@
       <Command><%eval(prelink)%></Command>
     </PreLinkEvent>
 <%endif%>
-<%if(type_is_static)%>
+<%if(type_is_static && staticname)%>
     <Lib>
 <%if(staticname)%>
       <OutputFile><%libout%>\<%libname_prefix%><%staticname%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%lib_ext%></OutputFile>
 <%endif%>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies><%foreach(reverse(libs))%><%fornotfirst(";")%><%libname_prefix%><%lib%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%lib_ext%><%endfor%><%foreach(reverse(lit_libs))%>;<%lit_lib%>.lib<%endfor%><%foreach(reverse(pure_libs))%> <%pure_lib%><%endfor%>;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories><%foreach(libpaths)%><%libpath%>;<%endfor%>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
 <%if(SuppressStartupBanner)%>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -406,7 +416,8 @@
 <%if(GenerateDebugInformation)%>
       <GenerateDebugInformation><%GenerateDebugInformation%></GenerateDebugInformation>
 <%endif%>
-      <AdditionalDependencies><%foreach(reverse(libs))%><%libname_prefix%><%lib%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%lib_ext%>;<%endfor%><%foreach(reverse(lit_libs))%><%lit_lib%>.lib;<%endfor%><%foreach(reverse(pure_libs))%> <%pure_lib%>;<%endfor%>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies><%foreach(reverse(libs))%><%fornotfirst(";")%><%libname_prefix%><%lib%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%lib_ext%><%endfor%><%foreach(reverse(lit_libs))%>;<%lit_lib%>.lib<%endfor%><%foreach(reverse(pure_libs))%> <%pure_lib%><%endfor%>;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories><%foreach(libpaths)%><%libpath%>;<%endfor%>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
 <%if(exename || sharedname || staticname)%>
       <OutputFile>$(OutDir)<%if(type_is_dynamic)%><%libname_prefix%><%sharedname%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%dll_ext%><%else%><%exename%><%if(use_exe_modifier)%><%lib_modifier%><%endif%><%exe_ext%><%endif%></OutputFile>
 <%endif%>
@@ -425,7 +436,9 @@
 <%if(PerUserRedirection)%>
       <PerUserRedirection>true</PerUserRedirection>
 <%endif%>
+<!--
       <AdditionalLibraryDirectories><%foreach(libpaths)%><%libpath%>;<%endfor%>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+	  -->
 <%if(LinkStatus)%>
       <LinkStatus>true</LinkStatus>
 <%endif%>
@@ -846,9 +859,9 @@
 <%endfor%>
   </ItemGroup>
 <%endif%>
-<%if(resource_files && !type_is_static)%>
+<%if(resource_files)%>
   <ItemGroup>
-<%foreach(resource_files)%>
+<%foreach(uniq(resource_files))%>
     <<%if(ends_with(resource_file,\.rc))%>ResourceCompile<%else%>None<%endif%> Include="<%resource_file%>" />
 <%endfor%>
   </ItemGroup>


### PR DESCRIPTION
MPC is a best tool to manage C++ project, the version below 2010 works well, but not works for vc2013,  I managed to correct the bug and make all my VC2008 project successfully upgraded to VC2013. I tested type for MFC\DLL\LIB etc.