### PR TITLE
Add in static lib aggregation for a debug build for msdev

### DIFF
--- a/templates/vc10.mpd
+++ b/templates/vc10.mpd
@@ -342,7 +342,7 @@
 <%if(staticname)%>
       <OutputFile><%libout%>\<%libname_prefix%><%staticname%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%lib_ext%></OutputFile>
 <%endif%>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies><%foreach(reverse(libs))%><%libname_prefix%><%lib%><%if(use_lib_modifier)%><%lib_modifier%><%endif%><%lib_ext%>;<%endfor%><%foreach(reverse(lit_libs))%><%lit_lib%>.lib;<%endfor%><%foreach(reverse(pure_libs))%> <%pure_lib%>;<%endfor%>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories><%foreach(libpaths)%><%libpath%>;<%endfor%>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
 <%if(SuppressStartupBanner)%>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
It seems that when a static lib for msdev is created any static dependencies are not aggregated into the parent project in a debug build.

This change attempts to resolve this.

@jonboan FYI
