### PR TITLE
VS2017 Language Standard setting by extending vc10 template

### DIFF
--- a/docs/templates/vc10.txt
+++ b/docs/templates/vc10.txt
@@ -79,6 +79,7 @@ intdir = Specify this to override the default intermediate directory.
 keycontainer = Specify a key container to sign an assembly.
 keyfile = Specify key or key pair to sign an assembly.  If set, embedmanifest defaults to false.
 largeaddressaware = Tells the linker that the application can handle addresses larger than 2 gigabytes.
+languagestandard = Which version of ISO C++ standard to compile against (stdcpp14, stdcpp17, stdcpplatest) - Visual Studio 2017+ only
 lib_options = Additional command-line options for the librarian.
 link_options = Additional command-line options for the linker.
 linkerrorreporting = Allows you to provide linker internal compiler error (ICE) information directly to the Visual C++ team (PromptImmediately, QueueForNextLogin, SendErrorReport, NoErrorReport).

--- a/templates/vc10.mpd
+++ b/templates/vc10.mpd
@@ -231,6 +231,9 @@
 <%if(OpenMP || OpenMPSupport)%>
       <OpenMPSupport>true</OpenMPSupport>
 <%endif%>
+<%if(LanguageStandard)%>
+      <LanguageStandard><%LanguageStandard%></LanguageStandard>
+<%endif%>
 <%if(pch_header)%>
       <PrecompiledHeader>Use</PrecompiledHeader>
 <%if(pch_header_output)%>


### PR DESCRIPTION
Alternative to #43 in response to the suggestion from @jwillemsen about maintenance.