### PR TITLE
When using clang on Linux disable some warnings on the RTI generaterd…

### DIFF
--- a/config/nddslib.mpb
+++ b/config/nddslib.mpb
@@ -15,6 +15,9 @@ project {
     endif
     ifeq ($(ACE_PLATFORM_CONFIG),config-linux.h)
     FLAGS_C_CC += -DRTI_LINUX
+    ifeq ($(CXX),clang++)
+    FLAGS_C_CC += -Wno-return-type-c-linkage -Wno-deprecated-register
+    endif
     endif
     ifeq ($(ACE_PLATFORM_CONFIG),config-android.h)
     FLAGS_C_CC += -DRTI_LINUX


### PR DESCRIPTION
… code, issue #4574

    * config/nddslib.mpb: