### PR TITLE
qt5 with -type gnuace

### DIFF
--- a/config/qt5_core.mpb
+++ b/config/qt5_core.mpb
@@ -26,7 +26,7 @@ project {
 
   // On Linux at least, Qt5 by default requires position independent code
   specific (gnuace) {
-    compile_flags += $(PIC)
+    compile_flags += $(if $(PIC),$(PIC),-fPIC)
   }
 
   specific (prop:microsoft) {
@@ -65,4 +65,3 @@ project {
     source_outputext = .cpp
   }
 }
-


### PR DESCRIPTION
provide workaround in case no PIC flag is defined (such as static_libs_only)