### PR TITLE
Pinpp update to pin3.14 for x64 linux using make

### DIFF
--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -4,9 +4,11 @@ project {
   includes += $(PIN_ROOT)/source/include \
               $(PIN_ROOT)/source/include/pin \
               $(PIN_ROOT)/source/include/pin/gen \
-              $(PIN_ROOT)/extras/components/include
+              $(PIN_ROOT)/extras/components/include \
+              ..
 
-  macros += BIGARRAY_MULTIPLIER=1 USING_XED
+  macros += BIGARRAY_MULTIPLIER=1 USING_XED PIN_CRT=1 __PIN__=1
+  lit_libs += c-dynamic m-dynamic stlport-dynamic
 
   specific (vc9) {
     runtime_library = 0
@@ -34,7 +36,7 @@ project {
   }
 
   specific (gnuace, make) {
-    compile_flags += -O3 -fomit-frame-pointer -fno-strict-aliasing -Wno-unknown-pragmas -fno-stack-protector -fPIC
+    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -faligned-new -fPIC -isystem $(PIN_ROOT)/extras/stlport/include -isystem $(PIN_ROOT)/extras/libstdc++/include -isystem $(PIN_ROOT)/extras/crt/include -isystem $(PIN_ROOT)/extras/crt/include/arch-x86_64 -isystem $(PIN_ROOT)/extras/crt/include/kernel/uapi -isystem $(PIN_ROOT)/extras/crt/include/kernel/asm-x86_64 -I$(PIN_ROOT)/source/include/pin -I$(PIN_ROOT)/source/include/pin/gen -I$(PIN_ROOT)/extras/components/include -I$(PIN_ROOT)/extras/xed-intel64/include/xed -nostdlib
     compile_flags -= -Wunused-parameter
 
     libs += xed
@@ -100,4 +102,5 @@ feature(intel64) {
     // DO NOT CHANGE ORDER
     lit_libs += libcpmt libcmt pinvm pin libxed ntdll-64
   }
+
 }

--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -36,7 +36,8 @@ project {
   }
 
   specific (gnuace, make) {
-    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -faligned-new -fPIC -isystem $(PIN_ROOT)/extras/stlport/include -isystem $(PIN_ROOT)/extras/libstdc++/include -isystem $(PIN_ROOT)/extras/crt/include -isystem $(PIN_ROOT)/extras/crt/include/arch-x86_64 -isystem $(PIN_ROOT)/extras/crt/include/kernel/uapi -isystem $(PIN_ROOT)/extras/crt/include/kernel/asm-x86_64 -I$(PIN_ROOT)/source/include/pin -I$(PIN_ROOT)/source/include/pin/gen -I$(PIN_ROOT)/extras/components/include -I$(PIN_ROOT)/extras/xed-intel64/include/xed -nostdlib -fpermissive -Wno-error=all -fno-exceptions
+    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -faligned-new -fPIC -nostdlib -fpermissive -Wno-error=all -fno-exceptions
+    compile_flags += '-isystem $(PIN_ROOT)/extras/stlport/include -isystem $(PIN_ROOT)/extras/libstdc++/include -isystem $(PIN_ROOT)/extras/crt/include -isystem $(PIN_ROOT)/extras/crt/include/kernel/uapi'
     compile_flags -= -Wunused-parameter
 
     libs += xed
@@ -88,7 +89,8 @@ feature(ia32) {
 }
 
 feature(intel64) {
-  includes += $(PIN_ROOT)/extras/xed-intel64/include
+  includes += $(PIN_ROOT)/extras/xed-intel64/include \
+              $(PIN_ROOT)/extras/xed-intel64/include/xed
 
   libpaths += $(PIN_ROOT)/intel64/lib \
               $(PIN_ROOT)/intel64/lib-ext \
@@ -101,6 +103,10 @@ feature(intel64) {
   specific (prop:windows) {
     // DO NOT CHANGE ORDER
     lit_libs += libcpmt libcmt pinvm pin libxed ntdll-64
+  }
+
+  specific (make, gnuace) {
+    compile_flags += -isystem $(PIN_ROOT)/extras/crt/include/arch-x86_64 -isystem $(PIN_ROOT)/extras/crt/include/kernel/asm-x86_64
   }
 
 }

--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -8,7 +8,7 @@ project {
               ..
 
   macros += BIGARRAY_MULTIPLIER=1 USING_XED PIN_CRT=1 __PIN__=1
-  lit_libs += c-dynamic m-dynamic stlport-dynamic
+  lit_libs += c-dynamic m-dynamic stlport-dynamic dl-dynamic unwind-dynamic
 
   specific (vc9) {
     runtime_library = 0
@@ -36,7 +36,7 @@ project {
   }
 
   specific (gnuace, make) {
-    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -faligned-new -fPIC -isystem $(PIN_ROOT)/extras/stlport/include -isystem $(PIN_ROOT)/extras/libstdc++/include -isystem $(PIN_ROOT)/extras/crt/include -isystem $(PIN_ROOT)/extras/crt/include/arch-x86_64 -isystem $(PIN_ROOT)/extras/crt/include/kernel/uapi -isystem $(PIN_ROOT)/extras/crt/include/kernel/asm-x86_64 -I$(PIN_ROOT)/source/include/pin -I$(PIN_ROOT)/source/include/pin/gen -I$(PIN_ROOT)/extras/components/include -I$(PIN_ROOT)/extras/xed-intel64/include/xed -nostdlib
+    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -faligned-new -fPIC -isystem $(PIN_ROOT)/extras/stlport/include -isystem $(PIN_ROOT)/extras/libstdc++/include -isystem $(PIN_ROOT)/extras/crt/include -isystem $(PIN_ROOT)/extras/crt/include/arch-x86_64 -isystem $(PIN_ROOT)/extras/crt/include/kernel/uapi -isystem $(PIN_ROOT)/extras/crt/include/kernel/asm-x86_64 -I$(PIN_ROOT)/source/include/pin -I$(PIN_ROOT)/source/include/pin/gen -I$(PIN_ROOT)/extras/components/include -I$(PIN_ROOT)/extras/xed-intel64/include/xed -nostdlib -fpermissive -Wno-error=all -fno-exceptions
     compile_flags -= -Wunused-parameter
 
     libs += xed

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -14,11 +14,11 @@ project : pin {
   verbatim (make, macros) {
     ifeq ($(shell uname -s), Darwin)
       CPPFLAGS += -DTARGET_MAC
-      LDFLAGS  += $(PIN_ROOT)/intel64/runtime/pincrt/crtbeginS.o -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
+      LDFLAGS  += -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
       LDFLAGS  -= -lpthread
     else
-      CPPFLAGS += -DTARGET_LINUX -fno-rtti -Wl,--hash-style=sysv $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
-      LDLIBS   += -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf -L$(PIN_ROOT)/intel64/runtime/pincrt
+      CPPFLAGS += -DTARGET_LINUX -fno-rtti -Wl,--hash-style=sysv
+      LDLIBS   += -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }
@@ -30,7 +30,7 @@ project : pin {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
-      LIBS     += -lpindwarf -L$(PIN_ROOT)/intel64/runtime/pincrt
+      LIBS     += -lpindwarf
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }
@@ -53,5 +53,10 @@ feature (intel64) {
 
   specific (vc10, vc11, vc12, vc14, vs2017, vs2019) {
     EntryPointSymbol = Ptrace_DllMainCRTStartup
+  }
+
+  specific (make, gnuace) {
+    compile_flags += $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
+    libpaths += $(PIN_ROOT)/intel64/runtime/pincrt
   }
 }

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -14,11 +14,11 @@ project : pin {
   verbatim (make, macros) {
     ifeq ($(shell uname -s), Darwin)
       CPPFLAGS += -DTARGET_MAC
-      LDFLAGS  += -lpindwarf -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
+      LDFLAGS  += $(PIN_ROOT)/intel64/runtime/pincrt/crtbeginS.o -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
       LDFLAGS  -= -lpthread
     else
-      CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
-      LDLIBS   += -lpindwarf
+      CPPFLAGS += -DTARGET_LINUX -fno-rtti -Wl,--hash-style=sysv $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
+      LDLIBS   += -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf -L$(PIN_ROOT)/intel64/runtime/pincrt
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }
@@ -30,7 +30,7 @@ project : pin {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
-      LIBS     += -lpindwarf
+      LIBS     += -lpindwarf -L$(PIN_ROOT)/intel64/runtime/pincrt
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }


### PR DESCRIPTION
builds pin tools using pinpp on pin3.14, cpp11 still doesn't work in pin though so a lot of functionality is lacking.