### PR TITLE
glib: support for finding headers directly in GLIB_ROOT/include

### DIFF
--- a/config/glib.mpb
+++ b/config/glib.mpb
@@ -10,9 +10,16 @@ project {
     lib
   }
 
-  includes      += $(GLIB_ROOT)/include/glib-$(GLIB_VERSION) \
-                   $(GLIB_ROOT)/$(GLIB_LIB_DIR)/glib-$(GLIB_VERSION)/include
   libpaths      += $(GLIB_ROOT)/lib
 
   lit_libs      += glib-$(GLIB_VERSION)
+}
+
+feature(glib_versioned_includes) {
+  includes += $(GLIB_ROOT)/include/glib-$(GLIB_VERSION) \
+              $(GLIB_ROOT)/$(GLIB_LIB_DIR)/glib-$(GLIB_VERSION)/include
+}
+
+feature(!glib_versioned_includes) {
+  includes += $(GLIB_ROOT)/include
 }

--- a/config/glib.mpb
+++ b/config/glib.mpb
@@ -22,4 +22,9 @@ feature(glib_versioned_includes) {
 
 feature(!glib_versioned_includes) {
   includes += $(GLIB_ROOT)/include
+  libpaths -= $(GLIB_ROOT)/lib
+  specific {
+    Debug::libpaths += $(GLIB_ROOT)/debug/lib
+    Release::libpaths += $(GLIB_ROOT)/lib
+  }
 }


### PR DESCRIPTION
conditional based on an MPC feature, default is to work as it did before this change