### PR TITLE
fix: updated base projects for pin 3.21

### DIFF
--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -4,11 +4,16 @@ project {
   includes += $(PIN_ROOT)/source/include \
               $(PIN_ROOT)/source/include/pin \
               $(PIN_ROOT)/source/include/pin/gen \
+	          $(PIN_ROOT)/extras/stlport/include \
+	          $(PIN_ROOT)/extras/libstdc++/include \
+	          $(PIN_ROOT)/extras/crt/include \
+	          $(PIN_ROOT)/extras/crt/include/kernel/uapi \
+	          $(PIN_ROOT)/extras/crt/include/kernel/uapi/asm-x86 \
+	          $(PIN_ROOT)/libunwind/include \
               $(PIN_ROOT)/extras/components/include \
-              $(PIN_ROOT)/extras/crt/include
+	          $(PIN_ROOT)/extras/crt/include
 
   macros += BIGARRAY_MULTIPLIER=1 USING_XED PIN_CRT=1 __PIN__=1
-  lit_libs += c-dynamic m-dynamic stlport-dynamic dl-dynamic unwind-dynamic
 
   specific (vc9) {
     runtime_library = 0
@@ -36,18 +41,20 @@ project {
   }
 
   specific (gnuace, make) {
-    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -faligned-new -fPIC -nostdlib -fpermissive -Wno-error=all -fno-exceptions
-    compile_flags += '-isystem $(PIN_ROOT)/extras/stlport/include -isystem $(PIN_ROOT)/extras/libstdc++/include -isystem $(PIN_ROOT)/extras/crt/include -isystem $(PIN_ROOT)/extras/crt/include/kernel/uapi'
+    compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -fPIC -nostdlib -fpermissive -Wno-error=all -fno-exceptions
     compile_flags -= -Wunused-parameter
 
     libs += xed
+    libs += c-dynamic m-dynamic stlport-dynamic unwind-dynamic 
   }
 
   verbatim (make, macros) {
     ifeq ($(shell uname -s), Darwin)
-      CPPFLAGS += -DTARGET_MAC
+      CPPFLAGS += -DTARGET_MAC -D__DARWIN_ONLY_UNIX_CONFORMANCE=1 -D__DARWIN_UNIX03=0
+      LDFLAGS  += -Wl,-no_new_main
     else
-      CPPFLAGS += -DTARGET_LINUX
+      CPPFLAGS += -DTARGET_LINUX -faligned-new
+      LDFLAGS  += -ldl-dynamic
     endif
 
     // We have to disable hidden symbols since we are not manually exporting
@@ -57,15 +64,16 @@ project {
 
   verbatim (gnuace, macros) {
     ifeq ($(shell uname -s), Darwin)
-      CPPFLAGS += -DTARGET_MAC
+      CPPFLAGS += -DTARGET_MAC -D__DARWIN_ONLY_UNIX_CONFORMANCE=1 -D__DARWIN_UNIX03=0
     else
-      CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
+      CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv -faligned-new
     endif
   }
 }
 
 feature(ia32) {
-  includes += $(PIN_ROOT)/extras/xed-ia32/include
+  includes += $(PIN_ROOT)/extras/xed-ia32/include \
+              $(PIN_ROOT)/extras/crt/include/arch-x86
 
   libpaths += $(PIN_ROOT)/ia32/lib \
               $(PIN_ROOT)/ia32/lib-ext \
@@ -90,12 +98,14 @@ feature(ia32) {
 
 feature(intel64) {
   includes += $(PIN_ROOT)/extras/xed-intel64/include \
-              $(PIN_ROOT)/extras/xed-intel64/include/xed
+              $(PIN_ROOT)/extras/xed-intel64/include/xed \
+	          $(PIN_ROOT)/extras/crt/include/arch-x86_64
 
   libpaths += $(PIN_ROOT)/intel64/lib \
               $(PIN_ROOT)/intel64/lib-ext \
               $(PIN_ROOT)/extras/xed-intel64/lib \
-              $(PIN_ROOT)/extras/components/lib/intel64
+              $(PIN_ROOT)/extras/components/lib/intel64 \
+              $(PIN_ROOT)/intel64/runtime/pincrt
 
   macros += TARGET_IA32E HOST_IA32E
   avoids += ia32

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -14,11 +14,11 @@ project : pin {
   verbatim (make, macros) {
     ifeq ($(shell uname -s), Darwin)
       CPPFLAGS += -DTARGET_MAC
-      LDFLAGS  += -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
+      LDFLAGS  += -nostdlib -lpin3dwarf -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -fno-rtti -Wl,--hash-style=sysv
-      LDLIBS   += -nostdlib -ldl-dynamic -lunwind-dynamic -lpin3dwarf
+      LDLIBS   += -nostdlib -ldl-dynamic -lpin3dwarf
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }
@@ -26,7 +26,7 @@ project : pin {
   verbatim (gnuace, macros) {
     ifeq ($(shell uname -s), Darwin)
       CPPFLAGS += -DTARGET_MAC
-      LDFLAGS  += -lpindwarf -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
+      LDFLAGS  += -lpinpthread -Wl,-exported_symbols_list -Wl,$(PIN_ROOT)/source/include/pin/pintool.exp
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
@@ -53,10 +53,5 @@ feature (intel64) {
 
   specific (prop:microsoft) {
     EntryPointSymbol = Ptrace_DllMainCRTStartup
-  }
-
-  specific (make, gnuace) {
-    compile_flags += $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
-    libpaths += $(PIN_ROOT)/intel64/runtime/pincrt
   }
 }

--- a/config/pintool_static.mpb
+++ b/config/pintool_static.mpb
@@ -10,7 +10,6 @@ project : pin_static {
   verbatim (make, macros) {
     ifeq ($(shell uname -s), Darwin)
       CPPFLAGS += -DTARGET_MAC
-      LDFLAGS  += -lpindwarf -lpinpthread
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX
@@ -23,7 +22,6 @@ project : pin_static {
   verbatim (gnuace, macros) {
     ifeq ($(shell uname -s), Darwin)
       CPPFLAGS += -DTARGET_MAC
-      LDFLAGS  += -lpindwarf -lpinpthread
       LDFLAGS  -= -lpthread
     else
       # TODO Add support for linking against gcc libraries included with Pin


### PR DESCRIPTION
This PR updates the Pin base projects to work with pin 3.21. We are not concerned with supporting older versions of Pin.