### PR TITLE
fix: fixed build issues for Pin 3.21 on linux

### DIFF
--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -42,10 +42,11 @@ project {
 
   specific (gnuace, make) {
     compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -fPIC -nostdlib -fpermissive -Wno-error=all -fno-exceptions
-    compile_flags -= -Wunused-parameter
+    compile_flags -= -Wunused-parameter -nostdlib
 
     libs += xed
-    libs += c-dynamic m-dynamic stlport-dynamic unwind-dynamic 
+    libs += c-dynamic m-dynamic stlport-dynamic unwind-dynamic
+    ldlibs = 
   }
 
   verbatim (make, macros) {

--- a/config/pin_static.mpb
+++ b/config/pin_static.mpb
@@ -1,4 +1,6 @@
 project : pin {
+  requires += static
+  
   specific (!prop:windows) {
     libs += sapin
     libs -= pin

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -19,7 +19,7 @@ project : pin {
     else
       CPPFLAGS += -DTARGET_LINUX -fno-rtti -Wl,--hash-style=sysv
       LDLIBS   += -nostdlib -ldl-dynamic -lpin3dwarf
-      LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
+      LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver $(PIN_ROOT)/intel64/runtime/pincrt/crtbeginS.o $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
     endif
   }
 
@@ -30,7 +30,6 @@ project : pin {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
-      LIBS     += -lpindwarf
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }

--- a/config/pintool_static.mpb
+++ b/config/pintool_static.mpb
@@ -1,4 +1,9 @@
 project : pin_static {
+  specific (gnuace, make) {
+    libs += c-static os-apis
+    libs -= c-dynamic m-dynamic stlport-dynamic unwind-dynamic xed
+  }
+  
   verbatim (make, top) {
     no_hidden_visibility = 1
   }
@@ -14,8 +19,7 @@ project : pin_static {
     else
       CPPFLAGS += -DTARGET_LINUX
       LDFLAGS  += -Wl,--hash-style=sysv -Wl,-Bsymbolic
-      LDFLAGS  -= -ldl -lpthread
-      LDLIBS   += -lpindwarf -ldl
+      LDLIBS   += -static $(PIN_ROOT)/intel64/runtime/pincrt/crtbeginS.o $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
     endif
   }
 
@@ -26,7 +30,7 @@ project : pin_static {
     else
       # TODO Add support for linking against gcc libraries included with Pin
       CPPFLAGS += -DTARGET_LINUX
-      LIBS     += -lpindwarf
+      LIBS     += -static
       LDFLAGS  += -Wl,--hash-style=sysv -Wl,-Bsymbolic
     endif
   }


### PR DESCRIPTION
This pull-request fixes build issues for Intel Pintools on Linux 64-bit architectures.