### PR TITLE
openssl may use lib64

### DIFF
--- a/config/openssl.mpb
+++ b/config/openssl.mpb
@@ -11,6 +11,7 @@ feature(openssl) {
   expand(SSL_LIBDIR) {
     $SSL_LIBDIR
     $(SSL_ROOT)/lib
+    $(SSL_ROOT)/lib64
   }
 
   includes += $(SSL_INCDIR)


### PR DESCRIPTION
Problem
-------

openssl may install to lib64.

Solution
--------

Add this to the mpb file for openssl.