### PR TITLE
fix: added support for static tools in pin-3.26

### DIFF
--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -4,8 +4,8 @@ project {
   includes += $(PIN_ROOT)/source/include \
               $(PIN_ROOT)/source/include/pin \
               $(PIN_ROOT)/source/include/pin/gen \
-	          $(PIN_ROOT)/extras/stlport/include \
-	          $(PIN_ROOT)/extras/libstdc++/include \
+              	  $(PIN_ROOT)/extras/cxx/include \
+              	  $(PIN_ROOT)/extras/libstdc++/include \
 	          $(PIN_ROOT)/extras/crt/include \
 	          $(PIN_ROOT)/extras/crt/include/kernel/uapi \
 	          $(PIN_ROOT)/extras/crt/include/kernel/uapi/asm-x86 \
@@ -42,10 +42,11 @@ project {
 
   specific (gnuace, make) {
     compile_flags += -O3 -funwind-tables -fno-stack-protector -fasynchronous-unwind-tables -fomit-frame-pointer -fno-strict-aliasing -fno-rtti -fPIC -nostdlib -fpermissive -Wno-error=all -fno-exceptions
-    compile_flags -= -Wunused-parameter
+    compile_flags -= -Wunused-parameter -nostdlib
 
     libs += xed
-    libs += c-dynamic m-dynamic stlport-dynamic unwind-dynamic 
+    libs += c-dynamic m-dynamic c++ c++abi unwind-dynamic
+    ldlibs =
   }
 
   verbatim (make, macros) {

--- a/config/pin_base.mpb
+++ b/config/pin_base.mpb
@@ -46,7 +46,6 @@ project {
 
     libs += xed
     libs += c-dynamic m-dynamic c++ c++abi unwind-dynamic
-    ldlibs =
   }
 
   verbatim (make, macros) {

--- a/config/pin_static.mpb
+++ b/config/pin_static.mpb
@@ -1,5 +1,5 @@
 project : pin {
-requires += static
+  requires += static
   specific (!prop:windows) {
     libs += sapin
     libs -= pin

--- a/config/pin_static.mpb
+++ b/config/pin_static.mpb
@@ -1,4 +1,5 @@
 project : pin {
+requires += static
   specific (!prop:windows) {
     libs += sapin
     libs -= pin

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -18,8 +18,8 @@ project : pin {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -fno-rtti -Wl,--hash-style=sysv
-      LDLIBS   += -nostdlib -ldl-dynamic -lpin3dwarf
-      LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
+      LDLIBS   += -nostdlib -ldl-dynamic -lpindwarf
+      LDFLAGS  += -Wl,-Bsymbolic -Wl,$(PIN_ROOT)/intel64/runtime/pincrt/crtbeginS.o $(PIN_ROOT)/intel64/runtime/pincrt/crtendS.o
     endif
   }
 
@@ -30,7 +30,6 @@ project : pin {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
-      LIBS     += -lpindwarf
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }
@@ -38,7 +37,7 @@ project : pin {
 
 feature (ia32) {
   specific (vc9) {
-    link_options += /ENTRY:Ptrace_DllMainCRTStartup@12
+    link_	options += /ENTRY:Ptrace_DllMainCRTStartup@12
   }
 
   specific (prop:microsoft) {

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -30,6 +30,7 @@ project : pin {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX -Wl,--hash-style=sysv
+      LIBS     += -lpindwarf
       LDFLAGS  += -Wl,-Bsymbolic -Wl,--version-script=$(PIN_ROOT)/source/include/pin/pintool.ver
     endif
   }

--- a/config/pintool.mpb
+++ b/config/pintool.mpb
@@ -38,7 +38,7 @@ project : pin {
 
 feature (ia32) {
   specific (vc9) {
-    link_	options += /ENTRY:Ptrace_DllMainCRTStartup@12
+    link_options += /ENTRY:Ptrace_DllMainCRTStartup@12
   }
 
   specific (prop:microsoft) {

--- a/config/pintool_static.mpb
+++ b/config/pintool_static.mpb
@@ -1,9 +1,4 @@
 project : pin_static {
-  specific (gnuace, make) {
-    libs += c-static os-apis
-    libs -= c-dynamic m-dynamic stlport-dynamic unwind-dynamic xed
-  }
-  
   verbatim (make, top) {
     no_hidden_visibility = 1
   }

--- a/config/pintool_static.mpb
+++ b/config/pintool_static.mpb
@@ -1,4 +1,9 @@
 project : pin_static {
+  specific (gnuace, make) {
+    libs += c-static os-apis
+    libs -= c-dynamic m-dynamic stlport-dynamic unwind-dynamic xed
+  }
+  
   verbatim (make, top) {
     no_hidden_visibility = 1
   }
@@ -13,9 +18,8 @@ project : pin_static {
       LDFLAGS  -= -lpthread
     else
       CPPFLAGS += -DTARGET_LINUX
-      LDFLAGS  += -Wl,--hash-style=sysv -Wl,-Bsymbolic
-      LDFLAGS  -= -ldl -lpthread
-      LDLIBS   += -lpindwarf -ldl
+      LDFLAGS  += -Wl,--hash-style=sysv -Wl,-Bsymbolic,$(PIN_ROOT)/intel64/runtime/pincrt/crtbegin.o $(PIN_ROOT)/intel64/runtime/pincrt/crtend.o
+      LDLIBS += -nostdlib -ldl-dynamic -lpindwarf
     endif
   }
 
@@ -26,7 +30,7 @@ project : pin_static {
     else
       # TODO Add support for linking against gcc libraries included with Pin
       CPPFLAGS += -DTARGET_LINUX
-      LIBS     += -lpindwarf
+      LIBS     += -static
       LDFLAGS  += -Wl,--hash-style=sysv -Wl,-Bsymbolic
     endif
   }

--- a/config/pintool_static.mpb
+++ b/config/pintool_static.mpb
@@ -25,7 +25,6 @@ project : pin_static {
     else
       # TODO Add support for linking against gcc libraries included with Pin
       CPPFLAGS += -DTARGET_LINUX
-      LIBS     += -static
       LDFLAGS  += -Wl,--hash-style=sysv -Wl,-Bsymbolic
     endif
   }


### PR DESCRIPTION
Made changes to support the compilation of Static pintools using pin-3.26 on Linux Platforms.