### PR TITLE
Fixed directory issue with -workers

### DIFF
--- a/modules/WorkspaceCreator.pm
+++ b/modules/WorkspaceCreator.pm
@@ -1802,7 +1802,7 @@ sub generate_project_files_fork {
     }
 
     $self->{'cacheok'} = $cacheok;
-    my $full = "$cwd/$dir";
+    my $full = $self->path_is_relative($dir) ? "$cwd/$dir" : $dir;
     if ($self->cd($full)) {
       if ($self->{'cacheok'} && defined $allprojects{$prkey}) {
 

--- a/modules/WorkspaceCreator.pm
+++ b/modules/WorkspaceCreator.pm
@@ -1802,7 +1802,8 @@ sub generate_project_files_fork {
     }
 
     $self->{'cacheok'} = $cacheok;
-    if ($self->cd($dir)) {
+    my $full = "$cwd/$dir";
+    if ($self->cd($full)) {
       if ($self->{'cacheok'} && defined $allprojects{$prkey}) {
 
         $files_written = $allprojects{$prkey};
@@ -1840,8 +1841,7 @@ sub generate_project_files_fork {
       ## Unable to change to the directory.
       ## We don't restore the state before we leave,
       ## but that's ok since we will be exiting soon.
-      return 0, $creator, $msg;
-
+      return 0, $creator, "Unable to change directory to $full";
     }
 
     ## Return things to the way they were


### PR DESCRIPTION
The issue can be reproduced by running the following in the root directory of OpenDDS on Windows at a cmd prompt.

`%ACE_ROOT%\bin\mwc.pl -type vs2022 -workers 2 DDS_no_tests.mwc tests\unit-tests`

The workers will have different current working directories, but that wasn't taken into account when processing the data after the workers had completed.