### PR TITLE
Don't add -language C++ in MPC as defaults, there are multiple C++ la…

### DIFF
--- a/config/ndds_ts_defaults.mpb
+++ b/config/ndds_ts_defaults.mpb
@@ -2,7 +2,7 @@
 project {
   Define_Custom(NDDSTypeSupport) {
     command               = <%quote%>$(NDDSSCRIPTDIR)/rtiddsgen<%quote%>
-    commandflags          = -language C++ -replace -namespace $(PLATFORM_NDDS_FLAGS)
+    commandflags          = -replace -namespace $(PLATFORM_NDDS_FLAGS)
 
     dependent             = $(NDDSSCRIPTDIR)/rtiddsgen<%bat%>
 


### PR DESCRIPTION
…nguage mappings, the user has to select which one

    * config/ndds_ts_defaults.mpb: