### PR TITLE
CppUnit uses the 'd' library suffix in Debug mode

### DIFF
--- a/config/cppunit.mpb
+++ b/config/cppunit.mpb
@@ -2,5 +2,5 @@
 project {
   includes += $(CPPUNIT_ROOT)/include
   libpaths += $(CPPUNIT_ROOT)/lib
-  lit_libs += cppunit
+  libs += cppunit
 }


### PR DESCRIPTION
See https://cgit.freedesktop.org/libreoffice/cppunit/tree/INSTALL-WIN32.txt?h=cppunit-1.15.1#n102