### PR TITLE
Remove -namespace argument from the default rtiddsgen arguments, it i…

### DIFF
--- a/config/ndds_ts_defaults.mpb
+++ b/config/ndds_ts_defaults.mpb
@@ -2,7 +2,7 @@
 project {
   Define_Custom(NDDSTypeSupport) {
     command               = <%quote%>$(NDDSSCRIPTDIR)/rtiddsgen<%quote%>
-    commandflags          = -replace -namespace $(PLATFORM_NDDS_FLAGS)
+    commandflags          = -replace $(PLATFORM_NDDS_FLAGS)
 
     dependent             = $(NDDSSCRIPTDIR)/rtiddsgen<%bat%>
 


### PR DESCRIPTION
…s for the C++98 mapping only and only used by some users

    * config/ndds_ts_defaults.mpb: