### PR TITLE
Removed dependent, not useful because it is just a driver script and …

### DIFF
--- a/config/ndds_ts_defaults.mpb
+++ b/config/ndds_ts_defaults.mpb
@@ -4,8 +4,6 @@ project {
     command               = <%quote%>$(NDDSHOME)/bin/rtiddsgen<%quote%>
     commandflags          = $(PLATFORM_NDDS_FLAGS)
 
-    dependent             = $(NDDSHOME)/bin/rtiddsgen<%bat%>
-
     source_pre_extension  = , Support, Plugin
     source_outputext      = .cxx
     header_pre_extension  = , Support, Plugin


### PR DESCRIPTION
…causes problems on windows with gnu make

    * config/ndds_ts_defaults.mpb: