### PR TITLE
Add support for parallel compilation for the Embarcadero bcc64x compiler

### DIFF
--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -99,6 +99,10 @@ RC           = <%rc%>
 LIBFLAGS     = <%libflags%>
 CCFLAGS      = $(CC_CFLAGS)<%if(type_is_binary)%> $(BINARY_FLAGS)<%endif%><%if(compile_flags)%> <%compile_flags%><%endif%>
 
+!ifndef MPC_NUMBER_OF_PROCESSORS
+MPC_NUMBER_OF_PROCESSORS = $(NUMBER_OF_PROCESSORS)
+!endif
+
 .nosilent
 
 <%if(use_vcl)%>

--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -219,8 +219,7 @@ CFLAGS = \
 OUTPUTDIR = $(EXEOUTPUTDIR)
 all:<%if(prebuild)%> __prebuild__<%endif%> $(OUTPUTDIR)$(NAME)$(EXE_EXT)<%if(postbuild)%> __postbuild__<%endif%>
 
-$(OUTPUTDIR)$(NAME)$(EXE_EXT): $(OBJFILES) $(RESOURCE)
-  @if not exist "$(OUTPUTDIR)" mkdir "$(OUTPUTDIR)"
+$(OUTPUTDIR)$(NAME)$(EXE_EXT): $(INTERMEDIATE) $(OUTPUTDIR) $(OBJFILES) $(RESOURCE)
 <%if(prelink)%>
   <%eval(prelink)%>
 <%endif%>
@@ -234,8 +233,7 @@ $(OUTPUTDIR)$(NAME)$(EXE_EXT): $(OBJFILES) $(RESOURCE)
 OUTPUTDIR = <%if(dllout)%><%dllout%><%else%><%libout%><%endif%>\\
 all:<%if(prebuild)%> __prebuild__<%endif%> $(OUTPUTDIR)$(NAME)$(DLL_EXT)<%if(postbuild)%> __postbuild__<%endif%>
 
-$(OUTPUTDIR)$(NAME)$(DLL_EXT): $(OBJFILES) $(RESOURCE)
-  @if not exist "$(OUTPUTDIR)" mkdir "$(OUTPUTDIR)"
+$(OUTPUTDIR)$(NAME)$(DLL_EXT): $(INTERMEDIATE) $(OUTPUTDIR) $(OBJFILES) $(RESOURCE)
 <%if(prelink)%>
   <%eval(prelink)%>
 <%endif%>
@@ -250,8 +248,7 @@ $(OUTPUTDIR)$(NAME)$(DLL_EXT): $(OBJFILES) $(RESOURCE)
 OUTPUTDIR = <%libout%>\\
 all:<%if(prebuild)%> __prebuild__<%endif%> $(OUTPUTDIR)$(NAME)$(LIB_EXT)<%if(postbuild)%> __postbuild__<%endif%>
 
-$(OUTPUTDIR)$(NAME)$(LIB_EXT): $(OBJFILES)
-  @if not exist "$(OUTPUTDIR)" mkdir "$(OUTPUTDIR)"
+$(OUTPUTDIR)$(NAME)$(LIB_EXT): $(INTERMEDIATE) $(OUTPUTDIR) $(OBJFILES)
   $(TLIB) $(LIBFLAGS) $(OUTPUTDIR)$(NAME)$(LIB_EXT) @&&!
 + $(**: = &^
 + )
@@ -315,45 +312,47 @@ all:<%if(prebuild)%> __prebuild__<%endif%> $(GENERATED_DIRTY)<%if(postbuild)%> _
 generated: $(GENERATED_DIRTY)
   @-rem
 
+$(INTERMEDIATE):
+  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
+
+<%if(exename || sharedname || staticname)%>
+$(OUTPUTDIR):
+  @if not exist "$(OUTPUTDIR)" mkdir "$(OUTPUTDIR)"
+<%endif%>
+
 .path$(OBJ_EXT) = $(INTERMEDIATE)
 
 !ifdef PARALLEL_CFLAGS
 .path.cpp = $(CPPDIR)
 .cpp$(OBJ_EXT):
-  if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
   $(CC) $(PARALLEL_CFLAGS) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -output-dir $(@D) -c {$? }
 
 !else
 .path.cpp = $(CPPDIR)
 .cpp$(OBJ_EXT):
-  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
-        $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+  (CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
 !endif
 
 .path.cxx = $(CPPDIR)
 .cxx$(OBJ_EXT):
-  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
-        $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+  $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
 
 .path.cc = $(CPPDIR)
 .cc$(OBJ_EXT):
-  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
-        $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+  $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
 
 .path.C = $(CPPDIR)
 .C$(OBJ_EXT):
-  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
-        $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+  $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
 
 .path.c = $(CPPDIR)
 .c$(OBJ_EXT):
-  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
-        $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+  $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
 
 <%foreach(source_files)%>
 <%if(transdir(source_file) || flag_overrides(source_file, buildflags))%>
-"$(INTERMEDIATE)\<%transdir(source_file)%><%basenoextension(source_file)%>$(OBJ_EXT)":
-  @if not exist "$(INTERMEDIATE)\<%transdir(source_file)%>" mkdir "$(INTERMEDIATE)\<%transdir(source_file)%>"
+"$(INTERMEDIATE)\<%transdir(source_file)%><%basenoextension(source_file)%>$(OBJ_EXT)"
+  if not exist "$(INTERMEDIATE)\<%transdir(source_file)%>" mkdir "$(INTERMEDIATE)\<%transdir(source_file)%>"
   $(CC) <%if(flag_overrides(source_file, buildflags))%><%flag_overrides(source_file, buildflags)%> <%endif%>$(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) <%source_file%>
 <%endif%>
 <%endfor%>
@@ -362,12 +361,12 @@ generated: $(GENERATED_DIRTY)
 .path.res = $(INTERMEDIATE)
 .path.rc = $(RESDIR)
 .rc.res:
-  @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
-        $(RC) $(RC_FLAGS) -fo$@ $<
+  if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
+  $(RC) $(RC_FLAGS) -fo$@ $<
 <%foreach(resource_files)%>
 <%if(transdir(resource_file))%>
 "$(INTERMEDIATE)\<%transdir(resource_file)%><%basenoextension(resource_file)%>.res":
-  @if not exist "$(INTERMEDIATE)\<%transdir(resource_file)%>" mkdir "$(INTERMEDIATE)\<%transdir(resource_file)%>"
+  if not exist "$(INTERMEDIATE)\<%transdir(resource_file)%>" mkdir "$(INTERMEDIATE)\<%transdir(resource_file)%>"
   $(RC) -fo$@ <%resource_file%>
 <%endif%>
 <%endfor%>

--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -334,7 +334,7 @@ $(OUTPUTDIR):
 !else
 .path.cpp = $(CPPDIR)
 .cpp$(OBJ_EXT):
-  (CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+  $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
 !endif
 
 .path.cxx = $(CPPDIR)

--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -355,7 +355,7 @@ $(OUTPUTDIR):
 
 <%foreach(source_files)%>
 <%if(transdir(source_file) || flag_overrides(source_file, buildflags))%>
-"$(INTERMEDIATE)\<%transdir(source_file)%><%basenoextension(source_file)%>$(OBJ_EXT)"
+"$(INTERMEDIATE)\<%transdir(source_file)%><%basenoextension(source_file)%>$(OBJ_EXT)":
   if not exist "$(INTERMEDIATE)\<%transdir(source_file)%>" mkdir "$(INTERMEDIATE)\<%transdir(source_file)%>"
   $(CC) <%if(flag_overrides(source_file, buildflags))%><%flag_overrides(source_file, buildflags)%> <%endif%>$(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) <%source_file%>
 <%endif%>

--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -42,6 +42,7 @@ EXEFLAGS = <%exeflags%>
 LINKER_DLL_ARGUMENTS = <%linker_dll_arguments%>
 LINKER_EXE_ARGUMENTS = <%linker_exe_arguments%>
 DEBUG_EXT = <%debug_ext%>
+<%if(parallel_flags)%>PARALLEL_CFLAGS = <%parallel_flags%><%endif%>
 !else
 <%endfor%>
 !error You must select one of these compilers:<%foreach(compilers)%> <%normalize(uc(compiler))%><%endfor%>
@@ -97,6 +98,8 @@ EXE_EXT      = <%exe_ext%>
 RC           = <%rc%>
 LIBFLAGS     = <%libflags%>
 CCFLAGS      = $(CC_CFLAGS)<%if(type_is_binary)%> $(BINARY_FLAGS)<%endif%><%if(compile_flags)%> <%compile_flags%><%endif%>
+
+.nosilent
 
 <%if(use_vcl)%>
 STARTUP_LETTER = <%if(exename)%>w<%else%><%startup_letter%><%endif%>
@@ -314,10 +317,18 @@ generated: $(GENERATED_DIRTY)
 
 .path$(OBJ_EXT) = $(INTERMEDIATE)
 
+!ifdef PARALLEL_CFLAGS
+.path.cpp = $(CPPDIR)
+.cpp$(OBJ_EXT):
+  if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
+  $(CC) $(PARALLEL_CFLAGS) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -output-dir $(@D) -c {$? }
+
+!else
 .path.cpp = $(CPPDIR)
 .cpp$(OBJ_EXT):
   @if not exist "$(INTERMEDIATE)" mkdir "$(INTERMEDIATE)"
         $(CC) $(DYN_FLAGS) $(STATIC_FLAGS) $(OCFLAGS) $(CG_CFLAGS) $(UC_CFLAGS) $(THREAD_FLAGS) $(CCFLAGS) $(CFLAGS) $(WARN_FLAGS) -c -o $(@D)\$(@F) $<
+!endif
 
 .path.cxx = $(CPPDIR)
 .cxx$(OBJ_EXT):

--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -100,7 +100,7 @@ LIBFLAGS     = <%libflags%>
 CCFLAGS      = $(CC_CFLAGS)<%if(type_is_binary)%> $(BINARY_FLAGS)<%endif%><%if(compile_flags)%> <%compile_flags%><%endif%>
 
 !ifndef MPC_NUMBER_OF_PROCESSORS
-MPC_NUMBER_OF_PROCESSORS = $(NUMBER_OF_PROCESSORS)
+MPC_NUMBER_OF_PROCESSORS = 0
 !endif
 
 .nosilent

--- a/templates/bmakecommon.mpt
+++ b/templates/bmakecommon.mpt
@@ -140,5 +140,5 @@ exeflags = -tR
 object_search_path = 0
 linker_dll_arguments = $(DLLFLAGS) $(UC_LFLAGS) $(LFLAGS:\=/) $(OBJFILES:\=/) -o $(OUTPUTDIR:\=/)$(NAME)$(DLL_EXT) -Xlinker --out-implib -Xlinker $(OUTPUTDIR:\=/)$(NAME).lib $(LIBFILES:\=/) $(RESOURCE:\=/)
 linker_exe_arguments = $(EXEFLAGS) $(UC_LFLAGS) $(LFLAGS:\=/) $(OBJFILES:\=/) -o $(OUTPUTDIR:\=/)$(NAME)$(EXE_EXT) $(LIBFILES:\=/) $(RESOURCE:\=/)
-parallel_flags = --jobs=0
+parallel_flags = --jobs=$(MPC_NUMBER_OF_PROCESSORS)
 }

--- a/templates/bmakecommon.mpt
+++ b/templates/bmakecommon.mpt
@@ -140,4 +140,5 @@ exeflags = -tR
 object_search_path = 0
 linker_dll_arguments = $(DLLFLAGS) $(UC_LFLAGS) $(LFLAGS:\=/) $(OBJFILES:\=/) -o $(OUTPUTDIR:\=/)$(NAME)$(DLL_EXT) -Xlinker --out-implib -Xlinker $(OUTPUTDIR:\=/)$(NAME).lib $(LIBFILES:\=/) $(RESOURCE:\=/)
 linker_exe_arguments = $(EXEFLAGS) $(UC_LFLAGS) $(LFLAGS:\=/) $(OBJFILES:\=/) -o $(OUTPUTDIR:\=/)$(NAME)$(EXE_EXT) $(LIBFILES:\=/) $(RESOURCE:\=/)
+parallel_flags = --jobs=0
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parallel compilation by introducing new variables and flags.
  * Build process now automatically creates required directories if they do not exist.

* **Improvements**
  * Enhanced build targets to explicitly depend on output and intermediate directories.
  * Cleaned up build output by removing silent command prefixes for directory creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->