### PR TITLE
Add support for specifiying a language standard to bmake

### DIFF
--- a/docs/templates/bmake.txt
+++ b/docs/templates/bmake.txt
@@ -19,6 +19,7 @@ debug_prj = Indicates that the current template configuration is debug.  This is
 defines = Macros that are specific to a particular configuration.
 dllflags = Linker flags that are required to create a dynamic library.
 exeflags = Linker flags that are required to create an executable.
+languagestandard = Which version of ISO C++ standard to compile against (c++14, c++17, c++20, c++23)
 libflags = Flags that are required to create a static library.
 link = The name of the tool used to create dynamic libraries and executables.
 obj_ext = The extension given to object files.

--- a/templates/bmake.mpd
+++ b/templates/bmake.mpd
@@ -96,7 +96,8 @@ DLL_EXT      = <%dll_ext%>
 EXE_EXT      = <%exe_ext%>
 RC           = <%rc%>
 LIBFLAGS     = <%libflags%>
-CCFLAGS      = $(CC_CFLAGS)<%if(type_is_binary)%> $(BINARY_FLAGS)<%endif%><%if(compile_flags)%> <%compile_flags%><%endif%>
+CCFLAGS      = $(CC_CFLAGS)<%if(type_is_binary)%> $(BINARY_FLAGS)<%endif%><%if(compile_flags)%> <%compile_flags%><%endif%><%if(languagestandard)%> -std=<%languagestandard%><%endif%>
+
 
 <%if(use_vcl)%>
 STARTUP_LETTER = <%if(exename)%>w<%else%><%startup_letter%><%endif%>


### PR DESCRIPTION
    * docs/templates/bmake.txt:
    * templates/bmake.mpd:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Build templates now support selecting the ISO C++ standard (c++14, c++17, c++20, c++23) via a new configurable variable. When set, the appropriate compiler flag is applied automatically.

- Documentation
  - Added guidance on the new language standard variable, including supported values and how it influences compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->