### PR TITLE
Upgrade to vcpkg 2026.03.18

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install vcpkg
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 66c0373dc7fca549e5803087b9487edfe3aca0a1
+        vcpkgGitCommitId: c3867e714dd3a51c272826eea77267876517ed99
         runVcpkgInstall: true
     - name: create $ACE_ROOT/ace/config.h
       run: |


### PR DESCRIPTION
    * .github/workflows/windows.yml:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build workflow configuration to use an updated version of the vcpkg dependency manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->