### PR TITLE
Remove openssl11, OpenSSL 1.0 itself was supported until 2015

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,7 +78,6 @@ jobs:
         echo "ipv6=1" | out-file -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "xerces3=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "ssl=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
-        echo "openssl11=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "versioned_namespace=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
         echo "zlib=1" | out-file -append -encoding ASCII ${env:ACE_ROOT}/bin/MakeProjectCreator/config/default.features
       shell: pwsh

--- a/config/global.features
+++ b/config/global.features
@@ -20,7 +20,6 @@ erlang        = 0
 java          = 0
 mfc           = 0
 libpng        = 0
-openssl11     = 0
 python        = 0
 qt            = 0 // Qt3
 qt4           = 0

--- a/config/openssl.mpb
+++ b/config/openssl.mpb
@@ -19,7 +19,7 @@ feature(openssl) {
   }
 
   specific(prop:windows) {
-    lit_libs += libeay32 ssleay32
+    lit_libs += libssl libcrypto
     includes += $(SSL_ROOT)/inc32
     libpaths += $(SSL_ROOT)/out32dll $(SSL_ROOT)/out32
   } else {
@@ -46,12 +46,5 @@ feature(openssl) {
 
     lit_libs += ${OPENSSL_LIBRARIES}
     includes += ${OPENSSL_INCLUDE_DIR}
-  }
-}
-
-feature(openssl11) {
-  specific(prop:windows) {
-    lit_libs -= libeay32 ssleay32
-    lit_libs += libssl libcrypto
   }
 }

--- a/docs/html/MakeProjectCreator.html
+++ b/docs/html/MakeProjectCreator.html
@@ -6407,8 +6407,6 @@ class="Code">specific</em> clause.
 
                 <p class="Code">libpng = 0</p>
 
-                <p class="Code">openssl11 = 0</p>
-
                 <p class="Code">python = 0</p>
 
                 <p class="Code">qt = 0</p>


### PR DESCRIPTION
    * .github/workflows/windows.yml:
    * config/global.features:
    * config/openssl.mpb:
    * docs/html/MakeProjectCreator.html:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows builds to use the current OpenSSL libraries.
  * Enabled IPv6, Xerces3, and SSL features in Windows project generation.
  * Removed the obsolete OpenSSL 1.1 feature flag.

* **Documentation**
  * Updated the documented global feature list to remove the obsolete OpenSSL 1.1 entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->