### PR TITLE
Removed ancient custom locatins of openssl libs

### DIFF
--- a/config/openssl.mpb
+++ b/config/openssl.mpb
@@ -20,8 +20,6 @@ feature(openssl) {
 
   specific(prop:windows) {
     lit_libs += libssl libcrypto
-    includes += $(SSL_ROOT)/inc32
-    libpaths += $(SSL_ROOT)/out32dll $(SSL_ROOT)/out32
   } else {
     lit_libs += ssl crypto
 

--- a/config/openssl.mpb
+++ b/config/openssl.mpb
@@ -30,15 +30,6 @@ feature(openssl) {
     includes += /usr/kerberos/include
   }
 
-  // Some prepackaged installations of OpenSSL have libraries in different
-  // locations.
-  specific(prop:borland) {
-    libpaths += $(SSL_ROOT)/lib/Builder5
-  }
-  specific(prop:microsoft) {
-    libpaths += $(SSL_ROOT)/lib/VC
-  }
-
   specific(cmake) {
     // Undo the else of the !prop:windows above.
     lit_libs -= ssl crypto


### PR DESCRIPTION
    * config/openssl.mpb:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenSSL configuration compatibility by removing outdated, toolchain-specific library search paths.
  * Preserved existing handling for platform-specific include and library locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->